### PR TITLE
Fix void returns of void statements

### DIFF
--- a/src/vcodegen.cpp
+++ b/src/vcodegen.cpp
@@ -172,7 +172,17 @@ void CodegenVisitor::visit(FuncDefnNode* n)
 	this->compilationUnit->builder.SetInsertPoint(BB);
 
 	n->funcBody->accept(this);
-	this->compilationUnit->builder.CreateRet(this->consumeRetValue());
+	if (n->funcDecl->t == TypeName::tVoid)
+	{
+		// If the type of this function is void, don't return anything
+		this->compilationUnit->builder.CreateRet(nullptr);
+	}
+	else
+	{
+		// otherwise, whatever we return is based whatever evaluating the function
+		// body spat out
+		this->compilationUnit->builder.CreateRet(this->consumeRetValue());
+	}
 	// v1 = v2 op v3
 	// Builder.CreateFAdd(L, R, "addtmp");
 


### PR DESCRIPTION
Fix support for void functions and returns
- Turns out it worked fine in the AST generation (as far as I can see?) and the problem was in how we were handling generating the return types. A function like
```
void foo(x) { return; }
```
would work fine, since return is evaluated and retValue is set to nullptr, since returns expr is nullptr BUT if a function like
```
void foo(x) {}
```
There is no body to evaluate, so retValue is never set, therefore points to garbage, so when we tried to dereference this->retValue to pass to builder.CreateRet, it was just pointing to goobeldy-gook.  
Solution:  
Any return function with type void will return void, whether it has a return statement or not, so after evaluating the function body, just slap a builder.CreateRet(nullptr); on the end of all void functions, instead of checking retValue at all. We don't need to touch retValue at all, since it will either be garbage if it is uninitialized and it isn't our problem OR it already IS nullptr if we found a return; statement in the function body.