### PR TITLE
add support for relational ops (broken for floats)

### DIFF
--- a/src/vcodegen.cpp
+++ b/src/vcodegen.cpp
@@ -121,8 +121,18 @@ void CodegenVisitor::visit(RelationalOpNode* n)
 	llvm::Value* lval = this->consumeRetValue();
 	n->right->accept(this);
 	llvm::Value* rval = this->consumeRetValue();
-	this->setRetValue(GetLLVMRelationalOp(n->op, lval, rval));
-
+	// We only have to check the left nodes evaluated type since, due to semantic checking, left and right
+	// are guaranteed to have matching types by the time we get here
+	if (n->left->evaluatedType == TypeName::tFloat)
+	{
+		// Floating point comparison
+		this->setRetValue(GetLLVMRelationalOpFP(n->op, lval, rval));
+	}
+	else
+	{
+		// Integer comparison
+		this->setRetValue(GetLLVMRelationalOpInt(n->op, lval, rval));
+	}
 	// enum class RelationalOps
 	// {
 	// 	Eq, 
@@ -445,7 +455,7 @@ void CodegenVisitor::visit(ContinueNode* n)
 	// jump straight back to the closest above us start: statement in the same scope
 }	
 
-llvm::Value* CodegenVisitor::GetLLVMRelationalOp(RelationalOps r, llvm::Value* lhs, llvm::Value* rhs)
+llvm::Value* CodegenVisitor::GetLLVMRelationalOpInt(RelationalOps r, llvm::Value* lhs, llvm::Value* rhs)
 {
 	// translates from relational ops used in AST gen/semantic analysis into llvm native funcs
 	switch(r) 
@@ -462,6 +472,29 @@ llvm::Value* CodegenVisitor::GetLLVMRelationalOp(RelationalOps r, llvm::Value* l
 			return this->compilationUnit->builder.CreateICmpSLE(lhs, rhs);
 		case RelationalOps::Ge:
 			return this->compilationUnit->builder.CreateICmpSGE(lhs, rhs);
+		default:
+			llvm_unreachable("Invalid relational operator");
+			return nullptr;
+	}
+}
+
+llvm::Value* CodegenVisitor::GetLLVMRelationalOpFP(RelationalOps r, llvm::Value* lhs, llvm::Value* rhs)
+{
+	// translates from relational ops used in AST gen/semantic analysis into llvm native funcs
+	switch(r) 
+	{
+		case RelationalOps::Eq:
+			return this->compilationUnit->builder.CreateFCmpOEQ(lhs, rhs);
+		case RelationalOps::Ne:
+			return this->compilationUnit->builder.CreateFCmpONE(lhs, rhs);
+		case RelationalOps::Lt:
+			return this->compilationUnit->builder.CreateFCmpOLT(lhs, rhs);
+		case RelationalOps::Gt:
+			return this->compilationUnit->builder.CreateFCmpOGT(lhs, rhs);
+		case RelationalOps::Le:
+			return this->compilationUnit->builder.CreateFCmpOLE(lhs, rhs);
+		case RelationalOps::Ge:
+			return this->compilationUnit->builder.CreateFCmpOGE(lhs, rhs);
 		default:
 			llvm_unreachable("Invalid relational operator");
 			return nullptr;

--- a/src/vcodegen.hpp
+++ b/src/vcodegen.hpp
@@ -56,7 +56,8 @@ public:
 
 	llvm::Type* GetLLVMType(TypeName t);
 	llvm::Value* GetLLVMBinaryOp(BinaryOps b, llvm::Value* lhs, llvm::Value* rhs);
-	llvm::Value* GetLLVMRelationalOp(RelationalOps r, llvm::Value* lhs, llvm::Value* rhs);
+	llvm::Value* GetLLVMRelationalOpInt(RelationalOps r, llvm::Value* lhs, llvm::Value* rhs);
+	llvm::Value* GetLLVMRelationalOpFP(RelationalOps r, llvm::Value* lhs, llvm::Value* rhs);
 };
 
 #endif // ECE467_CODEGEN_HPP_INCLUDED


### PR DESCRIPTION
Adds support for relational operators.  
- Turns out there are different comparison operators for floats and ints so a bit more complicated than we thought, but not by much. Just grab evaluatedType of either of the nodes from the AST (they are guaranteed to be the same type due to semantic checking that happened earlier) and choose what type of relational op to call