### PR TITLE
mutable variable support

### DIFF
--- a/src/symtable.cpp
+++ b/src/symtable.cpp
@@ -34,6 +34,25 @@ bool SymbolTable::AddSymbol(std::string name, TypeName type, YYLTYPE loc)
 	return true;
 }
 
+bool SymbolTable::AddLLVMSymbol(std::string name, llvm::AllocaInst* val)
+{
+	// add this symbol to the currently in scope symbol table
+	// return true if it succeeded or false if this symbol already 
+	// exists in this scope. This is for use in the llvm IR generation
+	// phase so the only thing we need is the llvm::Value*
+	if (CurrentSymbolTable->find(name) != CurrentSymbolTable->end())
+	{
+		return false;	// already declared in this scope
+	}
+	// make our new symbol table entry
+	SymbolTableEntry* symbolTableEntry = new SymbolTableEntry();
+	symbolTableEntry->Name = name;
+	symbolTableEntry->val = val;
+	// add it to the current active symbol table
+	CurrentSymbolTable->insert(std::pair<std::string, SymbolTableEntry*>(name, symbolTableEntry));
+	return true;
+}
+
 void SymbolTable::PushScope()
 {								
 	// enter a new scope
@@ -78,6 +97,14 @@ SymbolTableEntry* SymbolTable::GetSymbol(std::string Symbol)
 		}
 		return found->second;
 	}
+	return nullptr;
+}
+
+llvm::AllocaInst* SymbolTable::GetLLVMValue(std::string Symbol)
+{
+	SymbolTableEntry* s = this->GetSymbol(Symbol);
+	if (s)
+		return s->val;
 	return nullptr;
 }
 

--- a/src/symtable.hpp
+++ b/src/symtable.hpp
@@ -12,6 +12,8 @@
 #include <list>		// used as stack, maybe change to vector?
 #include "common.hpp"
 #include "bridge.hpp"
+#include "llvm/IR/ValueHandle.h"
+#include "llvm/IR/Instructions.h"
 
 typedef struct 
 {
@@ -19,6 +21,7 @@ typedef struct
 	TypeName Type;					// type of symbol
 	YYLTYPE declarationLocation;	// location where symbol was defined
 	// Additional attributes would go here, CONST, etc.
+	llvm::AllocaInst* val;				// use this to hold llvm specific info, usually a pointer to a memory location
 } SymbolTableEntry;
 
 typedef struct 
@@ -45,7 +48,9 @@ private:
 public:
 	SymbolTable();
 	SymbolTableEntry* GetSymbol(std::string Symbol);
+	llvm::AllocaInst* GetLLVMValue(std::string Symbol);
 	bool AddSymbol(std::string Name, TypeName Type, YYLTYPE loc);
+	bool AddLLVMSymbol(std::string Name, llvm::AllocaInst* val);
 
 	void PushScope();
 	void PopScope();

--- a/src/vcodegen.hpp
+++ b/src/vcodegen.hpp
@@ -10,6 +10,7 @@
 #include "common.hpp"
 #include "nodes.hpp"
 #include "compiler.hpp"
+#include "symtable.hpp"
 // #include "llvm/IR/IRBuilder.h"
 // #include "llvm/IR/LLVMContext.h"
 // #include "llvm/IR/Module.h"
@@ -22,12 +23,14 @@ class CodegenVisitor : public NodeVisitor
 private:
 	llvm::Value* retValue;
 	std::map<std::string, llvm::Value*> symbolTable;
+	SymbolTable* symTable;
 
 public:
 	CompilationUnit* compilationUnit;
 	// Includes necessary to build IR
 	// will this live here and get init'ed somewhere else
 	CodegenVisitor();
+	~CodegenVisitor();
 	llvm::Value* consumeRetValue();
 	void setRetValue(llvm::Value* v);
 	void visit(VariableNode* n) override;
@@ -62,6 +65,8 @@ public:
 	llvm::Value* GetLLVMBinaryOpFP(BinaryOps b, llvm::Value* lhs, llvm::Value* rhs);
 	llvm::Value* GetLLVMRelationalOpInt(RelationalOps r, llvm::Value* lhs, llvm::Value* rhs);
 	llvm::Value* GetLLVMRelationalOpFP(RelationalOps r, llvm::Value* lhs, llvm::Value* rhs);
+
+	llvm::AllocaInst* CreateEntryBlockAlloca(llvm::Function* TheFunction, std::string VarName, llvm::Type* t);
 };
 
 #endif // ECE467_CODEGEN_HPP_INCLUDED


### PR DESCRIPTION
support for mutable variables
implemented using the symbol table class that we already had, if we gotta change it later at some point we will but for now this seems to be working!
ie.
```
int foo(int x)
{
    int y = 2 + x;
    y = y + 1;
    return y;
}

int main()
{
    return foo(3);
}
```

becomes

```
;moduleID = 'ece467'
source_filename = "ece467"

define i32 @foo(i32 %x) {
entry:
  %x1 = alloca i32
  store i32 %x, i32* %x1
  %y = alloca i 32
  %x2 = load i32, i32* %x1
  %0 = add %i32 2, %x2
  store i32 %0, i32* %y
  %y3 = load i32, i32* %y
  %1 = add i32 %y3, 1
  store i32 %1, i32* %y
  %y4 = load i32, i32* %y
  ret i32 %y4
}

define i32 @main() {
entry:
  %0 = call i32 @foo(i32 3)
  ret i32 %0
}
```

seems a bit verbose but I guess the idea is that we optimize this ir once we have it all built and it will get rid of the useless stuff? 