### PR TITLE
Command line fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,6 @@ project(ccc VERSION 0.0.1 DESCRIPTION "Cimple C Compiler" LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
-add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-unused-parameter -Wno-deprecated)
+add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-unused-parameter -Wno-deprecated-declarations)
 
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 
 set(SOURCES
+	argsparse.cpp
 	compiler.cpp
 	common.cpp
 	nodes.cpp

--- a/src/argsparse.cpp
+++ b/src/argsparse.cpp
@@ -4,14 +4,6 @@
 
 int parse_commands(int argc, char** argv, cmd_line_args* cmds)
 {
-	// init with defaults here
-	// cmds->printflag = 0;
-	// cmds->printir = 0;
-	// cmds->lexflag = 0;
-	// cmds->keep_pp = 0;
-	// cmds->optlevel = 1;
-	// cmds->filename = NULL;
-
 	int index;
 	int optcode;
 
@@ -23,66 +15,91 @@ int parse_commands(int argc, char** argv, cmd_line_args* cmds)
 		exit(0);
 	}
 
-	while ((optcode = getopt (argc, argv, "eialo:")) != -1)
-	{
-		switch (optcode)
-		{
-			case 'i':
-				cmds->printir = 1;
-				break;
-			case 'a':
-				// print
-				cmds->printflag = 1;
-				break;
-			case 'l':
-				// display lexing information
-				cmds->lexflag = 1;
-				break;
-			case 'e':
-				// don't erase preprocessed file
-				cmds->keep_pp = 1;
-				break;
-			case 'n':
-				try 
-				{
-					cmds->optlevel = std::stoi(optarg);
-				}
-				catch (const std::invalid_argument& ia) 
-				{
-					std::cerr << "Invalid argument to -o: " << optarg << '\n';
-				}
-				break;
-			case '?':
-				// todo: fix this up
-				if (optopt == 'o')
-				{
-					std::cerr << "Option -" << optopt << " requires an argument\n";
-				}
-				else
-				{
-					std::cerr << "Unknown option " << optopt << "\n";
-				}
-				return 1;
-			default:
-				exit(1);
-		}
-	}
+    const struct option longopts[] = {
+        {"print-lex", no_argument, 0, 'l'},
+        {"print-ir", no_argument, 0, 'i'},
+        {"print-ast", no_argument, 0, 'a'},
+        {"print-tokens", no_argument, 0, 'l'},
+        // {"print-pp", no_argument, 0, 'e'},
+        {"optimization-level", required_argument, 0, 'o'},
+        {"keep-preprocessed", no_argument, 0, 'e'},
+        {"help", no_argument, 0, 'h'},
+        {"version", no_argument, 0, 'v'},
+        {0, 0, 0, 0}
+    };
+
+    while ((optcode = getopt_long(argc, argv, "eialo:hv", longopts, &index)) != -1)
+    {
+        switch (optcode)
+        {
+            case 'v':
+                version_info();
+                exit(0);
+            case 'h':
+                usage();
+                exit(0);
+            case 'a':
+                cmds->printflag = 1;
+                break;
+            case 'i':
+                cmds->printir = 1;
+                break;
+            case 'l':
+                cmds->lexflag = 1;
+                break;
+            case 'p':
+                cmds->printflag = 1;
+                break;
+            case 'o':
+                cmds->optlevel = atoi(optarg);
+                break;
+            case 'e':
+                cmds->keep_pp = 1;
+                break;
+            case '?':
+                if (optopt == 'o')
+                {
+                    std::cerr << "Option -" << optopt << " requires an argument." << std::endl;
+                }
+                else if (isprint(optopt))
+                {
+                    std::cerr << "Unknown option -" << optopt << std::endl;
+                }
+                else
+                {
+                    std::cerr << "Unknown option character " << optopt << std::endl;
+                }
+                return 1;
+            default:
+                abort();
+        }
+    }
 
 	for (index = optind; index < argc; index++)
 	{
 		cmds->filename = argv[index];
-		// todo: gather the rest of argv to use as the arguments to our program
+		// todo: gather the rest of argv to use as the arguments to our program?
+        // or should we be able to build multiple programs probably? ie strcat it onto filename?
 	}
 	return 0;
 }
 
 void usage() 
 {
-	std::cout  	<< "[usage] ccc <args> <file> [compiled program args]\n"
-				<< " -o0	: Disable optimization\n"
-				<< " -o1	: Basic optimizations (default)\n"
-				<< " -l 	: Display lexer output\n"
-				<< " -a 	: Display AST\n"
-				<< " -i 	: Display generated IR\n"
-				<< " -e     : Keep preprocessed file (as filename.pp)\n";
+	std::cout  	<< "[usage] ccc <args> <file>\n"
+				<< " -o0\t--optimization-level 0\t\t: Disable optimization\n"
+				<< " -o1\t--optimization-level 1\t\t: Basic optimizations (default)\n"
+				<< " -l\t--print-lex\t\t\t: Display lexer output\n"
+				<< " -a\t--print-ast\t\t\t: Display AST\n"
+				<< " -i\t--print-ir\t\t\t: Display generated IR\n"
+				<< " -e\t--keep-preprocessed\t\t: Keep preprocessed file (as filename.pp)\n"
+                << " -h\t--help\t\t\t\t: Display this help message\n"
+                << " -v\t--version\t\t\t: Display version information\n";
+}
+
+void version_info()
+{
+    std::cout   << "ccc version 0.1\n"
+                << "By Tyler Weston\n"
+                << "2020/2021\n";
 }

--- a/src/argsparse.cpp
+++ b/src/argsparse.cpp
@@ -1,0 +1,88 @@
+#include "argsparse.hpp"
+#include <iostream>
+#include <getopt.h>
+
+int parse_commands(int argc, char** argv, cmd_line_args* cmds)
+{
+	// init with defaults here
+	// cmds->printflag = 0;
+	// cmds->printir = 0;
+	// cmds->lexflag = 0;
+	// cmds->keep_pp = 0;
+	// cmds->optlevel = 1;
+	// cmds->filename = NULL;
+
+	int index;
+	int optcode;
+
+	opterr = 0;
+
+	if (argc == 1)
+	{
+		usage();
+		exit(0);
+	}
+
+	while ((optcode = getopt (argc, argv, "eialo:")) != -1)
+	{
+		switch (optcode)
+		{
+			case 'i':
+				cmds->printir = 1;
+				break;
+			case 'a':
+				// print
+				cmds->printflag = 1;
+				break;
+			case 'l':
+				// display lexing information
+				cmds->lexflag = 1;
+				break;
+			case 'e':
+				// don't erase preprocessed file
+				cmds->keep_pp = 1;
+				break;
+			case 'n':
+				try 
+				{
+					cmds->optlevel = std::stoi(optarg);
+				}
+				catch (const std::invalid_argument& ia) 
+				{
+					std::cerr << "Invalid argument to -o: " << optarg << '\n';
+				}
+				break;
+			case '?':
+				// todo: fix this up
+				if (optopt == 'o')
+				{
+					std::cerr << "Option -" << optopt << " requires an argument\n";
+				}
+				else
+				{
+					std::cerr << "Unknown option " << optopt << "\n";
+				}
+				return 1;
+			default:
+				exit(1);
+		}
+	}
+
+	for (index = optind; index < argc; index++)
+	{
+		cmds->filename = argv[index];
+		// todo: gather the rest of argv to use as the arguments to our program
+	}
+	return 0;
+}
+
+void usage() 
+{
+	std::cout  	<< "[usage] ccc <args> <file> [compiled program args]\n"
+				<< " -o0	: Disable optimization\n"
+				<< " -o1	: Basic optimizations (default)\n"
+				<< " -l 	: Display lexer output\n"
+				<< " -a 	: Display AST\n"
+				<< " -i 	: Display generated IR\n"
+				<< " -e     : Keep preprocessed file (as filename.pp)\n";
+}

--- a/src/argsparse.hpp
+++ b/src/argsparse.hpp
@@ -13,5 +13,6 @@ struct cmd_line_args
 
 int parse_commands(int, char**, cmd_line_args*);
 void usage();
+void version_info();
 
 #endif // CCC_ARGPARSE_HPP_INCLUDED

--- a/src/argsparse.hpp
+++ b/src/argsparse.hpp
@@ -1,0 +1,17 @@
+#ifndef CCC_ARGPARSE_HPP_INCLUDED
+#define CCC_ARGPARSE_HPP_INCLUDED
+
+struct cmd_line_args
+{
+	int printflag = 0;
+	int lexflag = 0;
+	int printir = 0;
+	int optlevel = 1;
+	int keep_pp = 0;
+	char* filename = nullptr;
+};
+
+int parse_commands(int, char**, cmd_line_args*);
+void usage();
+
+#endif // CCC_ARGPARSE_HPP_INCLUDED

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "nodes.hpp"
 #include "preprocess.hpp"
 #include "main.hpp"
+#include "argsparse.hpp"
 #include <string>
 #include <unistd.h>
 
@@ -68,8 +69,6 @@ What other operators are there?
 
 
 using namespace std::string_literals;
-int parse_commands(int, char**, cmd_line_args*);
-static void usage();
 
 int main(int argc, char** argv) {
 	std::cout << "cimple c compiler - Tyler Weston - 2020\n";
@@ -141,89 +140,4 @@ int main(int argc, char** argv) {
 
 	std::cout << "All done!\n";
 	return 0;
-}
-
-int parse_commands(int argc, char** argv, cmd_line_args* cmds)
-{
-	// init with defaults here
-	// cmds->printflag = 0;
-	// cmds->printir = 0;
-	// cmds->lexflag = 0;
-	// cmds->keep_pp = 0;
-	// cmds->optlevel = 1;
-	// cmds->filename = NULL;
-
-	int index;
-	int optcode;
-
-	opterr = 0;
-
-	if (argc == 1)
-	{
-		usage();
-		exit(0);
-	}
-
-	while ((optcode = getopt (argc, argv, "eialo:")) != -1)
-	{
-		switch (optcode)
-		{
-			case 'i':
-				cmds->printir = 1;
-				break;
-			case 'a':
-				// print
-				cmds->printflag = 1;
-				break;
-			case 'l':
-				// display lexing information
-				cmds->lexflag = 1;
-				break;
-			case 'e':
-				// don't erase preprocessed file
-				cmds->keep_pp = 1;
-				break;
-			case 'n':
-				try 
-				{
-					cmds->optlevel = std::stoi(optarg);
-				}
-				catch (const std::invalid_argument& ia) 
-				{
-					std::cerr << "Invalid argument to -o: " << optarg << '\n';
-				}
-				break;
-			case '?':
-				// todo: fix this up
-				if (optopt == 'o')
-				{
-					std::cerr << "Option -" << optopt << " requires an argument\n";
-				}
-				else
-				{
-					std::cerr << "Unknown option " << optopt << "\n";
-				}
-				return 1;
-			default:
-				exit(1);
-		}
-	}
-
-	for (index = optind; index < argc; index++)
-	{
-		cmds->filename = argv[index];
-		// todo: gather the rest of argv to use as the arguments to our program
-	}
-	return 0;
-}
-
-static void usage() 
-{
-	std::cout  	<< "[usage] ccc <args> <file> [compiled program args]\n"
-				<< " -o0	: Disable optimization\n"
-				<< " -o1	: Basic optimizations (default)\n"
-				<< " -l 	: Display lexer output\n"
-				<< " -a 	: Display AST\n"
-				<< " -i 	: Display generated IR\n"
-				<< " -e     : Keep preprocessed file (as filename.pp)\n";
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,7 +71,7 @@ What other operators are there?
 using namespace std::string_literals;
 
 int main(int argc, char** argv) {
-	std::cout << "cimple c compiler - Tyler Weston - 2020\n";
+	std::cout << "cimple c compiler - Tyler Weston - 2020/2021\n";
  	cmd_line_args cmds;
 	parse_commands(argc, argv, &cmds);
 	// make sure we got a file

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -1,14 +1,16 @@
 #ifndef CCC_MAIN_HPP_INCLUDED
 #define CCC_MAIN_HPP_INCLUDED
 
-struct cmd_line_args
-{
-	int printflag = 0;
-	int lexflag = 0;
-	int printir = 0;
-	int optlevel = 1;
-	int keep_pp = 0;
-	char* filename = NULL;
-};
+// struct cmd_line_args
+// {
+// 	int printflag = 0;
+// 	int lexflag = 0;
+// 	int printir = 0;
+// 	int optlevel = 1;
+// 	int keep_pp = 0;
+// 	char* filename = NULL;
+// };
+
+#define noop 0
 
 #endif // CCC_MAIN_HPP_INCLUDED


### PR DESCRIPTION
move from getopt to getopt_long so you can use for example --version and -v or --print-ast. 